### PR TITLE
Replace `larapack/dd` with `symfony/var-dumper`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.2",
-        "larapack/dd": "^1.1",
         "phpstan/phpstan": "^1.10",
-        "friendsofphp/php-cs-fixer": "^3.21"
+        "friendsofphp/php-cs-fixer": "^3.21",
+        "symfony/var-dumper": "^7.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`larapack/dd` no longer provides any value, because now `symfony/var-dumper` ships `dd` and `dump` helpers on its own.