### PR TITLE
Bump version to 1.0-alpha2

### DIFF
--- a/.github/workflows/tempest-clean-quality-control.yml
+++ b/.github/workflows/tempest-clean-quality-control.yml
@@ -25,7 +25,7 @@ jobs:
         run:  composer init -ns dev
 
       - name: Require Tempest
-        run: composer require tempest/framework:1.0-alpha1
+        run: composer require tempest/framework:1.0-alpha2
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "tempest/app",
     "require": {
-        "tempest/framework": "1.0-alpha1"
+        "tempest/framework": "1.0-alpha2"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.2",


### PR DESCRIPTION
This allows users to install the latest and greatest version of Tempest using this template app.