### PR TITLE
Use same PHP process for scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     ],
     "scripts": {
         "post-create-project-cmd": [
-            "./vendor/bin/tempest install framework -f",
-            "./tempest discovery:generate",
+            "@php ./vendor/bin/tempest install framework -f",
+            "@php ./tempest discovery:generate",
             "rm -r .github"
         ],
         "post-package-update": [
-            "./tempest discovery:generate"
+            "@php ./tempest discovery:generate"
         ],
         "phpunit": "vendor/bin/phpunit --display-warnings --display-skipped --display-deprecations --display-errors --display-notices",
         "csfixer": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --allow-risky=yes",


### PR DESCRIPTION
Use `@php` to use the same php version that the main process starts. If you call the composer binary with a optional php versopn like `opt/php/php8.2/php composer update`. On shared hosting you don't have always proper configured php version on cli and web. 

https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts