### PR TITLE
allow PHPUnit 11, update PHPStan to 2.0 and fix `discovery:generate` being executed on each touched package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
         "tempest/framework": "dev-main"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.2",
-        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^10.2 || ^11.5",
+        "phpstan/phpstan": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.21",
         "symfony/var-dumper": "^7.1"
     },
@@ -32,7 +32,7 @@
             "@php ./tempest discovery:generate",
             "rm -r .github"
         ],
-        "post-package-update": [
+        "post-autoload-dump": [
             "@php ./tempest discovery:generate"
         ],
         "phpunit": "vendor/bin/phpunit --display-warnings --display-skipped --display-deprecations --display-errors --display-notices",


### PR DESCRIPTION
I noticed a weird thing with the discovery regenerate: it gets executed for each package which gets added/updated/removed when doing a composer command.

![image](https://github.com/user-attachments/assets/87144839-371a-4796-84ca-a667af4fbe2c)

The reason behind that was the fact, that the `post-package-update` hook of composer gets triggered for each (sub-)package being touched by composer.

The simplest solution would be to only regenerate the discovery cache, when the actual composer autoloader gets regenerated (which happens after either `composer install`, `composer update` or any `composer require` command)