### PR TITLE
fix: ignore logs by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 .env
 .idea
 .phpunit.result.cache
+log/


### PR DESCRIPTION
When an error happens or if I manually log something, the log files are added to the VCS because they're not in `.gitignore`. This PR fixes that. 

I'm not merging myself because I want confirmation from @brendt that it was not intended